### PR TITLE
Add Light capability and allow light level to be set as a percentage

### DIFF
--- a/haiku-driver.groovy
+++ b/haiku-driver.groovy
@@ -3,6 +3,7 @@ metadata {
         capability "FanControl"
         capability "SwitchLevel"
         capability "Switch"
+        capability "Light"
         capability "Refresh"
 
         command "reverseFan"
@@ -66,7 +67,9 @@ def parse(String description) {
                     } else {
                         events << createEvent(name: "switch", value: "on")
                     }
-                    events << createEvent(name: "level", value: values[4])
+                    level = Math.round(values[4].toInteger() * 6.25)
+                    log.debug "Using new level ${level}"
+                    events << createEvent(name: "level", value: level)
                     return events;
             }
             break
@@ -128,14 +131,17 @@ def setLevel(level, duration) {
 }
 
 def sendLightLevelCommand(level) {
-    if (level > 16) {
-        level = 16
+    if (level > 100) {
+        level = 100
     }
     if (level < 0) {
         level = 0
     }
+    
+    Integer haikuLevel = Math.round(level / 6.25)
+    log.debug "level [${level}] haikuLevel [${haikuLevel}]"
 
-    sendCommand("LIGHT", "LEVEL", "SET;${level}")
+    sendCommand("LIGHT", "LEVEL", "SET;${haikuLevel}")
 }
 
 def setSpeed(fanspeed){

--- a/haiku-driver.groovy
+++ b/haiku-driver.groovy
@@ -1,3 +1,5 @@
+import groovy.transform.Field
+
 metadata {
     definition(name: "Haiku Fan", namespace: "community", author: "Zack Brown") {
         capability "FanControl"
@@ -19,6 +21,16 @@ preferences {
         input("logEnable", "bool", title: "Enable debug logging", defaultValue: true)
     }
 }
+
+//
+// Constants
+//
+// Number of light graduations Haiku supports.
+@Field final int HAIKU_LIGHT_LEVELS = 16
+
+// Ratio of light levels to percentage level. 1 Haiku light level every 6.25%
+@Field final double HAIKU_LIGHT_SPREAD = (double)100/HAIKU_LIGHT_LEVELS
+
 
 def installed() {
     log.debug "installed"
@@ -67,8 +79,7 @@ def parse(String description) {
                     } else {
                         events << createEvent(name: "switch", value: "on")
                     }
-                    level = Math.round(values[4].toInteger() * 6.25)
-                    log.debug "Using new level ${level}"
+                    int level = (int)Math.ceil(values[4].toInteger() * HAIKU_LIGHT_SPREAD)
                     events << createEvent(name: "level", value: level)
                     return events;
             }
@@ -138,7 +149,7 @@ def sendLightLevelCommand(level) {
         level = 0
     }
     
-    Integer haikuLevel = Math.round(level / 6.25)
+    int haikuLevel = (int)Math.ceil(level / HAIKU_LIGHT_SPREAD)
     log.debug "level [${level}] haikuLevel [${haikuLevel}]"
 
     sendCommand("LIGHT", "LEVEL", "SET;${haikuLevel}")

--- a/haiku-driver.groovy
+++ b/haiku-driver.groovy
@@ -36,10 +36,6 @@ def installed() {
     log.debug "installed"
 }
 
-def initialize() {
-    log.debug "initialized"
-}
-
 def updated() {
     log.debug "updated"
 }


### PR DESCRIPTION
* Light capability was added to make the driver compatible with Hubitat-Homebridge.
* Level is changed to be a percentage, as per SwitchLevel capability standard. Internally we translate this back to Haikus 16 levels. This is required for functioning light control with Hubitat-Homebridge.